### PR TITLE
Add a way to consume oauth2 token

### DIFF
--- a/docs/source/users/oauth2_settings.rst
+++ b/docs/source/users/oauth2_settings.rst
@@ -112,4 +112,4 @@ Consideration before activating OAUTH2_STORE_TOKENS
 --------------------------------------------------
 
 In OAuth2.0, tokens are for the app, not the user, so the session
-must be secure to avoid security issue.
+must be secure to avoid security issues.

--- a/docs/source/users/oauth2_settings.rst
+++ b/docs/source/users/oauth2_settings.rst
@@ -108,7 +108,7 @@ Exemple of settings
    OAUTH2_TIMEOUT = 30
 
 
-Considertion before activating OAUTH2_STORE_TOKENS
+Consideration before activating OAUTH2_STORE_TOKENS
 --------------------------------------------------
 
 In OAuth2.0, tokens are for the app, not the user, so the session

--- a/docs/source/users/oauth2_settings.rst
+++ b/docs/source/users/oauth2_settings.rst
@@ -5,26 +5,42 @@ Configure OAuth2.0
 
 They are all prefixed by `OAUTH2_`:
 
+.. |br| raw:: html
 
-+---------------------------+---------------------------------------------------+-----------+
-| name                      | description                           | mandatory | type      |
-+===========================+=======================================+===========+===========+
-| OAUTH2_CLIENT_ID          | OAuth2.0 client id                    | yes       | str       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_CLIENT_SECRET      | OAuth2.0 client secret                | yes       | str       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_AUTH_URL           | /authorize endpoint                   | yes       | str       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_TOKEN_URL          | /token url                            | yes       | str       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_LOAD_USERINFO      | Load user info from the oauth2 server | yes       | callable  |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_LOGOUT_URL         | url to redirect on logout             | yes       | str       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_TIMEOUT            | HTTP Timeout in seconds               | no (30)   | int       |
-+---------------------------+---------------------------------------+-----------+-----------+
-| OAUTH2_VERIFY_CERTIFICATE | Check TLS while consuming tokens      | no (True) | bool      |
-+---------------------------+---------------------------------------+-----------+-----------+
+  <div style="line-height: 0; padding: 0; margin: 0"></div>
+
+
++---------------------------+---------------------------+---------------------+-----------+
+| name                      | description               | mandatory           | type      |
++===========================+===========================+=====================+===========+
+| OAUTH2_CLIENT_ID          | OAuth2.0 client id        | yes                 | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_CLIENT_SECRET      | OAuth2.0 client secret    | yes                 | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_AUTH_URL           | /authorize endpoint       | yes                 | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_TOKEN_URL          | /token url                | yes                 | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_LOAD_USERINFO      | Load user info |br|       | yes                 | callable  |
+|                           | from the oauth2 server    |                     |           |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_LOGOUT_URL         | url to redirect on logout | yes                 | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_TIMEOUT            | HTTP Timeout in seconds   | no (30)             | int       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_VERIFY_CERTIFICATE | Check TLS while |br|      | no (True)           | bool      |
+|                           | consuming tokens          |                     |           |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_STORE_TOKENS       | Save the tokens |br|      | no (False)          | bool      |
+|                           | in the django session     |                     |           |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_SESSION_KEY_PREFIX | Prefix of the key in |br| | no                  |           |
+|                           | the django session.       | (`wagtail_oauth2_`) | str       |
++---------------------------+---------------------------+---------------------+-----------+
+| OAUTH2_DEFAULT_TTL        | Fallback value if |br|    | no (900)            | int       |
+|                           | ``expires_in`` is         |                     |           |
+|                           | missing                   |                     |           |
++---------------------------+---------------------------+---------------------+-----------+
 
 
 The settings `OAUTH2_LOAD_USERINFO` is a function that takes an `access_token` in parameter,
@@ -90,3 +106,10 @@ Exemple of settings
 
    OAUTH2_VERIFY_CERTIFICATE = True
    OAUTH2_TIMEOUT = 30
+
+
+Considertion before activating OAUTH2_STORE_TOKENS
+--------------------------------------------------
+
+In OAuth2.0, tokens are for the app, not the user, so the session
+must be secure to avoid security issue.

--- a/docs/source/users/oauth2_settings.rst
+++ b/docs/source/users/oauth2_settings.rst
@@ -109,7 +109,7 @@ Exemple of settings
 
 
 Consideration before activating OAUTH2_STORE_TOKENS
---------------------------------------------------
+---------------------------------------------------
 
 In OAuth2.0, tokens are for the app, not the user, so the session
 must be secure to avoid security issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wagtail-oauth2"
-version = "0.2.0"
+version = "0.2.1"
 description = "OAuth2.0 authentication fo wagtail"
 authors = ["Guillaume Gauvrit <guillaume@gandi.net>"]
 readme = "README.rst"
@@ -32,6 +32,11 @@ Faker = "^10.0.0"
 Sphinx = "^4.3.1"
 sphinx-rtd-theme = "^1.0.0"
 tomlkit = "^0.7.2"
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+line_length = 88
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/wagtail_oauth2/tests/conftest.py
+++ b/src/wagtail_oauth2/tests/conftest.py
@@ -169,7 +169,6 @@ class RequestsMock(mock.Mock):
                 status, headers, res = api_response[(method, url)]
                 res = json.dumps(res)
             else:
-                breakpoint()
                 print(f"{method} {url} is missing returning missing results")
                 status, headers, res = missing_status, None, missing_body
             RequestsMock.api_calls[(method, url)].append(kwargs)

--- a/src/wagtail_oauth2/tests/conftest.py
+++ b/src/wagtail_oauth2/tests/conftest.py
@@ -108,6 +108,20 @@ API_RESPONSE: Dict[Tuple[str, str], Tuple[int, Any, Any]] = {
         # Body
         {},
     ),
+    (
+        "post",
+        "https://gandi.v5/token~client_id=Mei&client_secret=T0t0r0&grant_type=refresh_token&refresh_token=xyz",
+    ): (
+        200,
+        # Headers
+        {},
+        # Body
+        {
+            "access_token": "toktok",
+            "refresh_token": "totoro",
+            "expires_in": 3600,
+        },
+    ),
 }
 
 
@@ -155,6 +169,7 @@ class RequestsMock(mock.Mock):
                 status, headers, res = api_response[(method, url)]
                 res = json.dumps(res)
             else:
+                breakpoint()
                 print(f"{method} {url} is missing returning missing results")
                 status, headers, res = missing_status, None, missing_body
             RequestsMock.api_calls[(method, url)].append(kwargs)
@@ -185,3 +200,13 @@ def state():
 @pytest.fixture()
 def auth_code(mock_oauth2):
     return "codecode"
+
+
+class DummyRequestWithSession:
+    def __init__(self, session):
+        self.session = session or {}
+
+
+@pytest.fixture()
+def dummy_request_with_session(params):
+    yield DummyRequestWithSession(params.get("session"))

--- a/src/wagtail_oauth2/tests/test_utils.py
+++ b/src/wagtail_oauth2/tests/test_utils.py
@@ -1,0 +1,118 @@
+from unittest import mock
+import pytest
+from django.test import override_settings
+
+from wagtail_oauth2.utils import get_access_token, save_tokens
+
+
+@mock.patch("time.time", return_value=1000)
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "settings": {},
+            "tokens": {"access_token": "abc"},
+            "expected": {},
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True},
+            "tokens": {"access_token": "abc"},
+            "expected": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 1900,
+            },
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True, "OAUTH2_DEFAULT_TTL": 42},
+            "tokens": {"access_token": "abc"},
+            "expected": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 1042,
+            },
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True, "OAUTH2_DEFAULT_TTL": 42},
+            "tokens": {"access_token": "abc", "expires_in": 300},
+            "expected": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 1300,
+            },
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True},
+            "tokens": {
+                "access_token": "abc",
+                "refresh_token": "xyz",
+                "expires_in": 300,
+            },
+            "expected": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_refresh_token": "xyz",
+                "wagtail_oauth2_expires_at": 1300,
+            },
+        },
+    ],
+)
+def test_save_tokens(time, dummy_request_with_session, params):
+    tokens = params["tokens"]
+    settings = params["settings"]
+    expected = params["expected"]
+    with override_settings(**settings):
+        save_tokens(dummy_request_with_session, tokens)
+    assert dummy_request_with_session.session == expected
+
+
+@mock.patch("time.time", return_value=1000)
+@pytest.mark.parametrize(
+    "params",
+    [
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True},
+            "session": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 1300,
+            },
+            "expected": "abc",
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": True},
+            "session": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 300,
+            },
+            "expected": None,
+        },
+        {
+            "settings": {"OAUTH2_STORE_TOKENS": False},
+            "session": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_expires_at": 1300,
+            },
+            "expected": None,
+        },
+        {
+            # Expired Scenario
+            "settings": {
+                "OAUTH2_STORE_TOKENS": True,
+            },
+            "session": {
+                "wagtail_oauth2_access_token": "abc",
+                "wagtail_oauth2_refresh_token": "xyz",
+                "wagtail_oauth2_expires_at": 300,
+            },
+            "expected": "toktok",
+            "expected_new_session": {
+                "wagtail_oauth2_access_token": "toktok",
+                "wagtail_oauth2_expires_at": 4600,
+                "wagtail_oauth2_refresh_token": "totoro",
+            },
+        },
+    ],
+)
+def test_get_access_token(time, mock_oauth2, dummy_request_with_session, params):
+    settings = params["settings"]
+    with override_settings(**settings):
+        token = get_access_token(dummy_request_with_session)
+    assert token == params["expected"]
+    if "expected_new_session" in params:
+        assert dummy_request_with_session.session == params["expected_new_session"]

--- a/src/wagtail_oauth2/utils.py
+++ b/src/wagtail_oauth2/utils.py
@@ -1,0 +1,42 @@
+import time
+from typing import cast
+
+from .settings import get_setting
+from .resources import Token
+
+DEFAULT_SESSION_KEY_PREFIX = "wagtail_oauth2_"
+
+
+def save_tokens(request, tokens):
+    if not get_setting("STORE_TOKENS", False):
+        return None
+    prefix = get_setting("SESSION_KEY_PREFIX", DEFAULT_SESSION_KEY_PREFIX)
+    request.session[f"{prefix}access_token"] = tokens["access_token"]
+    if "refresh_token" in tokens:
+        request.session[f"{prefix}refresh_token"] = tokens["refresh_token"]
+    if "expires_in" in tokens:
+        request.session[f"{prefix}expires_at"] = int(time.time() + tokens["expires_in"])
+    else:
+        request.session[f"{prefix}expires_at"] = int(
+            time.time() + cast(float, get_setting("DEFAULT_TTL", 15 * 60))  # 15 minutes
+        )
+
+
+def get_access_token(request):
+    """Get the access token, or fetch a new one if it is possible, otherwise return None."""
+    if not get_setting("STORE_TOKENS", False):
+        return None
+
+    prefix = get_setting("SESSION_KEY_PREFIX", DEFAULT_SESSION_KEY_PREFIX)
+    access_token = request.session.get(f"{prefix}access_token")
+    refresh_token = request.session.get(f"{prefix}refresh_token")
+    expires_at = int(request.session.get(f"{prefix}expires_at", 0))
+
+    if access_token and expires_at > time.time():
+        return access_token
+
+    if refresh_token:
+        tokens = Token.by_refresh_token(refresh_token)
+        if tokens:
+            save_tokens(request, tokens)
+            return tokens["access_token"]


### PR DESCRIPTION
The idea here is to have a `get_access_token` token method to retrieve an access token for the connected user.

This is optional, by default we don't store the token, because storing a refresh token in a clear session is a bad
security, so developpers activating this feature must be warned about that.

